### PR TITLE
Added pagination support

### DIFF
--- a/src/main/scala/Engine.scala
+++ b/src/main/scala/Engine.scala
@@ -42,6 +42,7 @@ case class Query(
   returnSelf: Option[Boolean] = None, // means for an item query should the item itself be returned, defaults
   // to what is in the algorithm params or false
   num: Option[Int] = None, // default: whatever is in algorithm params, which itself has a default--probably 20
+  offset: Option[Int] = 0, // Used for pagination, default: 0
   eventNames: Option[List[String]], // names used to ID all user actions
   withRanks: Option[Boolean] = None) // Add to ItemScore rank fields values, default fasle
     extends Serializable

--- a/src/main/scala/URAlgorithm.scala
+++ b/src/main/scala/URAlgorithm.scala
@@ -529,6 +529,7 @@ class URAlgorithm(val ap: URAlgorithmParams)
       // purchase or view, we'll pass both to the query if the user history or items correlators are empty
       // then metadata or backfill must be relied on to return results.
       val numRecs = query.num.getOrElse(limit)
+      val offset = query.offset.getOrElse(0)
       val should = buildQueryShould(query, boostable)
       val must = buildQueryMust(query, boostable)
       val mustNot = buildQueryMustNot(query, events)
@@ -536,6 +537,7 @@ class URAlgorithm(val ap: URAlgorithmParams)
 
       val json =
         ("size" -> numRecs) ~
+        ("from" -> offset) ~
           ("query" ->
             ("bool" ->
               ("should" -> should) ~

--- a/src/main/scala/URAlgorithm.scala
+++ b/src/main/scala/URAlgorithm.scala
@@ -368,7 +368,8 @@ class URAlgorithm(val ap: URAlgorithmParams)
   /** Return a list of items recommended for a user identified in the query
    *  The ES json query looks like this:
    *  {
-   *    "size": 20
+   *    "size": 20,
+   *    "from": 0,
    *    "query": {
    *      "bool": {
    *        "should": [
@@ -396,14 +397,16 @@ class URAlgorithm(val ap: URAlgorithmParams)
    *              "category": ["cat1"],
    *              "boost": 0
    *            }
-   *          },
-   *         {
-   *        "must_not": [//blacklisted items
+   *          }
+   *        ],
+   *        "must_not": [ //blacklisted items
    *          {
    *            "ids": {
    *              "values": ["items-id1", "item-id2", ...]
    *            }
-   *          },
+   *          }
+   *        ]
+   *      },
    *         {
    *           "constant_score": {// date in query must fall between the expire and available dates of an item
    *             "filter": {


### PR DESCRIPTION
Added new Query parameter offset which is passed to ES query as from parameter.
Use case:
Fetch 25 recommendations for user by default (query.num=25). User wants to see the next 25 recommendations.
Currently you would have to set query.num=50 and programmatically remove first 25 results.
This PR will make it possible to pass query.offset=25, query.num=25.